### PR TITLE
Fixed a few different issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,8 +131,8 @@ repositories {
     // }
     maven {
         // location of the maven that hosts JEI files
-        name "Progwml6 maven"
-        url "https://dvs1.progwml6.com/files/maven/"
+        name "Jared's maven"
+        url "https://maven.blamejared.com"
         content {
             includeGroup "mezz.jei"
         }
@@ -152,10 +152,10 @@ dependencies {
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.19.2-43.2.0'
-    compileOnly fg.deobf("mezz.jei:jei-1.19.1-common-api:11.2.0.241")
-    compileOnly fg.deobf("mezz.jei:jei-1.19.1-forge-api:11.2.0.241")
+    compileOnly fg.deobf("mezz.jei:jei-1.19.2-common-api:11.6.0.1015")
+    compileOnly fg.deobf("mezz.jei:jei-1.19.2-forge-api:11.6.0.1015")
     // at runtime, use the full JEI jar for Forge
-    runtimeOnly fg.deobf("mezz.jei:jei-1.19.1-forge:11.2.0.241")
+    runtimeOnly fg.deobf("mezz.jei:jei-1.19.2-forge:11.6.0.1015")
     // and the full Configured jar for Forge
     runtimeOnly fg.deobf("curse.maven:Configured-457570:4462837")
 

--- a/src/main/java/com/buuz135/darkmodeeverywhere/ClientProxy.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/ClientProxy.java
@@ -53,7 +53,7 @@ public class ClientProxy {
             if (SHADER_VALUES.put(shaderValue.resourceLocation, shaderValue) == null) {
                 try {
                     event.registerShader(new ShaderInstance(event.getResourceManager(), shaderValue.resourceLocation, DefaultVertexFormat.POSITION_TEX), shaderInstance -> {
-                        DarkModeEverywhere.LOGGER.debug("Registered shader " + shaderValue.resourceLocation);
+                        DarkModeEverywhere.LOGGER.debug("Registered shader {}", shaderValue.resourceLocation);
                         REGISTERED_SHADERS.put(shaderValue.resourceLocation, shaderInstance);
                         REGISTERED_SHADER_LOCATIONS.add(shaderValue.resourceLocation);
                     });
@@ -77,7 +77,7 @@ public class ClientProxy {
 
     public static boolean isElementNameBlacklisted(String elementName) {
         return BLACKLISTED_ELEMENTS.computeIfAbsent(elementName, (String name) -> {
-            DarkModeEverywhere.LOGGER.debug("Considering " + name + " for element blacklist");
+            DarkModeEverywhere.LOGGER.debug("Considering {} for element blacklist", name);
             RenderedClassesTracker.add(name);
             return blacklistContains(MODDED_BLACKLIST, name) || blacklistContains(DarkConfig.CLIENT.METHOD_SHADER_BLACKLIST.get(), name);
         });

--- a/src/main/java/com/buuz135/darkmodeeverywhere/DarkConfig.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/DarkConfig.java
@@ -30,7 +30,8 @@ public class DarkConfig {
         public Client() {
             final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
             List<String> defaultBlacklist = new ArrayList<>(Arrays.asList(
-                "mezz.jei.common.render.FluidTankRenderer:drawTextureWithMasking",
+                "mezz.jei.common.render.FluidTankRenderer:drawTextureWithMasking",//1.19.1 JEI Path
+                "mezz.jei.library.render.FluidTankRenderer:drawTextureWithMasking",//1.19.2+ JEI Path
                 "renderCrosshair",
                 "net.minecraft.client.gui.screens.TitleScreen",
                 "renderSky",

--- a/src/main/java/com/buuz135/darkmodeeverywhere/DarkConfig.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/DarkConfig.java
@@ -32,14 +32,14 @@ public class DarkConfig {
             List<String> defaultBlacklist = new ArrayList<>(Arrays.asList(
                 "mezz.jei.common.render.FluidTankRenderer:drawTextureWithMasking",//1.19.1 JEI Path
                 "mezz.jei.library.render.FluidTankRenderer:drawTextureWithMasking",//1.19.2+ JEI Path
-                "renderCrosshair",
+                "renderCrosshair", "m_93080_",
                 "net.minecraft.client.gui.screens.TitleScreen",
-                "renderSky",
-                "renderHotbar",
+                "renderSky", "m_202423_",
+                "renderHotbar", "m_93009_", "m_193837_",//Normal hotbar, and spectator hotbar
                 "setupOverlayRenderState",
                 "net.minecraftforge.client.gui.overlay.ForgeGui",
                 "renderFood",
-                "renderExperienceBar"
+                "renderExperienceBar", "m_93071_"
             ));
 
             String TRANSLATION_KEY_BASE = "config." + DarkModeEverywhere.MODID + ".";

--- a/src/main/java/com/buuz135/darkmodeeverywhere/DarkModeEverywhere.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/DarkModeEverywhere.java
@@ -1,5 +1,6 @@
 package com.buuz135.darkmodeeverywhere;
 
+import com.mojang.logging.LogUtils;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -7,14 +8,12 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
 
 @Mod("darkmodeeverywhere")
 public class DarkModeEverywhere {
 
-    // Directly reference a log4j logger.
-    public static final Logger LOGGER = LogManager.getLogger();
+    public static final Logger LOGGER = LogUtils.getLogger();
     public static final String MODID = "darkmodeeverywhere";
 
     public DarkModeEverywhere() {

--- a/src/main/java/com/buuz135/darkmodeeverywhere/RenderedClassesTracker.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/RenderedClassesTracker.java
@@ -13,7 +13,7 @@ public class RenderedClassesTracker {
     public static void start(){
         new Thread(() -> {
             while (true) {
-                if (DarkConfig.CLIENT.METHOD_SHADER_DUMP.get()){
+                if (DarkConfig.CLIENT.METHOD_SHADER_DUMP.get() && !TRACKED.isEmpty()){
                     LOGGER.info("--------------------------------------------------");
                     TRACKED.forEach(LOGGER::info);
                     LOGGER.info("--------------------------------------------------");

--- a/src/main/java/com/buuz135/darkmodeeverywhere/RenderedClassesTracker.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/RenderedClassesTracker.java
@@ -1,21 +1,21 @@
 package com.buuz135.darkmodeeverywhere;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.util.HashMap;
+import com.mojang.logging.LogUtils;
+import java.util.HashSet;
+import java.util.Set;
+import org.slf4j.Logger;
 
 public class RenderedClassesTracker {
 
-    private static final HashMap<String, Boolean> TRACKED = new HashMap<>();
-    private static final Logger LOGGER = LogManager.getLogger("DME METHOD DUMP");
+    private static final Set<String> TRACKED = new HashSet<>();
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     public static void start(){
         new Thread(() -> {
             while (true) {
                 if (DarkConfig.CLIENT.METHOD_SHADER_DUMP.get()){
                     LOGGER.info("--------------------------------------------------");
-                    TRACKED.forEach((key, value) -> LOGGER.info(key));
+                    TRACKED.forEach(LOGGER::info);
                     LOGGER.info("--------------------------------------------------");
                     TRACKED.clear();
                 }
@@ -29,7 +29,7 @@ public class RenderedClassesTracker {
     }
 
     public static void add(String element){
-        if (DarkConfig.CLIENT.METHOD_SHADER_DUMP.get() && !TRACKED.containsKey(element)) TRACKED.put(element, true);
+        if (DarkConfig.CLIENT.METHOD_SHADER_DUMP.get()) TRACKED.add(element);
     }
 
 }

--- a/src/main/java/com/buuz135/darkmodeeverywhere/ShaderConfig.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/ShaderConfig.java
@@ -39,7 +39,7 @@ public class ShaderConfig {
         } else {
             selectedShader = resourceLocation.toString();
         }
-        DarkModeEverywhere.LOGGER.debug("Selected shader updated to " + selectedShader);
+        DarkModeEverywhere.LOGGER.debug("Selected shader updated to {}", selectedShader);
         new Thread(ShaderConfig::createDefaultConfigFile).start();
     }
 

--- a/src/main/java/com/buuz135/darkmodeeverywhere/ShaderConfig.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/ShaderConfig.java
@@ -47,15 +47,17 @@ public class ShaderConfig {
         return selectedShader;
     }
 
+    private static Gson createGson() {
+        return new GsonBuilder().setPrettyPrinting().registerTypeAdapter(Component.class, new Component.Serializer()).create();
+    }
+
     public static void load(){
         if (!configFilePath.exists()){
             createDefaultConfigFile();
         }
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        try {
-            FileReader reader = new FileReader(configFilePath);
+        Gson gson = createGson();
+        try (FileReader reader = new FileReader(configFilePath)) {
             ClientProxy.CONFIG = gson.fromJson(reader, ShaderConfig.class);
-            reader.close();
         } catch (Exception e) {
             e.printStackTrace();
             createDefaultConfigFile();
@@ -63,11 +65,9 @@ public class ShaderConfig {
     }
 
     private static void createDefaultConfigFile(){
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        try {
-            FileWriter fileWriter = new FileWriter(ShaderConfig.configFilePath);
+        Gson gson = createGson();
+        try (FileWriter fileWriter = new FileWriter(ShaderConfig.configFilePath)) {
             gson.toJson(ClientProxy.CONFIG, fileWriter);
-            fileWriter.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/buuz135/darkmodeeverywhere/mixins/GameRenderMixin.java
+++ b/src/main/java/com/buuz135/darkmodeeverywhere/mixins/GameRenderMixin.java
@@ -1,9 +1,11 @@
 package com.buuz135.darkmodeeverywhere.mixins;
 
 import com.buuz135.darkmodeeverywhere.ClientProxy;
+import cpw.mods.modlauncher.api.INameMappingService;
 import net.minecraft.client.gui.GuiComponent;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.ShaderInstance;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,6 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(GameRenderer.class)
 public class GameRenderMixin {
+    private static final String SET_SHADER_METHOD_NAME = ObfuscationReflectionHelper.remapName(INameMappingService.Domain.METHOD, "m_157427_");
+
     private static void replaceDefaultShaderWithSelectedShader(CallbackInfoReturnable<ShaderInstance> cir) {
         cir.setReturnValue(ClientProxy.REGISTERED_SHADERS.get(ClientProxy.SELECTED_SHADER));
     }
@@ -37,10 +41,11 @@ public class GameRenderMixin {
         StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
         for (int i=1; i<stElements.length; i++) {
             StackTraceElement ste = stElements[i];
-            if (!ste.getClassName().equals(GameRenderer.class.getName())
-                    && ste.getClassName().indexOf("java.lang.Thread")!=0
-                    && !ste.getMethodName().equals("setShader")
-                    && !ste.getClassName().equals(GuiComponent.class.getName())) {
+            String className = ste.getClassName();
+            if (!className.equals(GameRenderer.class.getName())
+                && className.indexOf("java.lang.Thread") != 0
+                && !ste.getMethodName().equals(SET_SHADER_METHOD_NAME)
+                && !className.equals(GuiComponent.class.getName())) {
                 return ste;
             }
         }


### PR DESCRIPTION
- JEI changed the path for the fluid renderer in 1.19.2 so now both the 1.19.1 and 1.19.2 paths are in the default blacklisted config #4
- Fixed IMC blacklisted methods being ignored #29 
- Removed exceptions as code flow for calculating if an element is blacklisted and instead use a primitive supporting map and computeIfAbsent
- Reduced unneeded/overly complex data structures in places where simpler or existing ones work fine
- Protect against any mods that might accidentally send an IMC message that isn't a string
- Use more modern and recommended ways of creating loggers in MC rather than directly using Log4J and avoid logging line spacers when there are no elements being printed to reduce log spam
- Fixed UnsupportedOperationException when trying to serialize Components when reading/writing the shader config
- Fixed blacklist not working in prod due to not filtering out the setShader method (wasn't checking the obf name)
- Also added obf variants of the various default blacklisted configs