### PR TITLE
Remove uneccessarily verbose release workflow config options

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,4 @@ jobs:
           files-secondary: build/libs/*-@(dev|sources).jar
           version-type: beta
           loaders: forge
-          game-versions: 1.18.1
-          java: 17
-          name: ""
           changelog: "https://github.com/Buuz135/DarkModeEverywhere/commits/main"


### PR DESCRIPTION
As described [here](https://github.com/Kir-Antipov/mc-publish#-unnecessary-verbose-example), it's better to omit most of the config as the workflow will compute the relevant info automatically. 